### PR TITLE
Add date params to completion script

### DIFF
--- a/bin/confirm/confirm-completion.js
+++ b/bin/confirm/confirm-completion.js
@@ -1,29 +1,28 @@
 #!/usr/bin/env node
 
 const resolve = require('path').resolve
-require('app-module-path').addPath(__dirname + '/../../');
+require('app-module-path').addPath(__dirname + '/../../')
 
-require('dotenv').config({ path: resolve('../..', '.env'), silent: true })
+require('dotenv').config({ path: resolve('../..', '.env'), silent: true })
 
-const { config } = require('./constants/config')
 const { selectConfig } = require('app-modules/constants/course-config')
-const Promise = require('bluebird');
-const _ = require('lodash');
-const mongoose = require('mongoose');
+const Promise = require('bluebird')
+const _ = require('lodash')
+const mongoose = require('mongoose')
 mongoose.Promise = require('bluebird').Promise
-const async = require('async')
 
-const quizTypes = require('app-modules/constants/quiz-types')
-const { validateAnswer, validateProgress } = require('app-modules/quiz-validation')
+const {
+  validateProgress,
+} = require('app-modules/quiz-validation')
 
 const Quiz = require('app-modules/models/quiz')
 const QuizAnswer = require('app-modules/models/quiz-answer')
-const PeerReview = require('app-modules/models/peer-review')
 const CourseState = require('app-modules/models/course-state')
 
 const { connect, fetchQuizIds } = require('./utils/quiznator-tools')
-const { median, calculatePercentage, printProgress } = require('./utils/mathutils')
-const { precise_round } = require('app-modules/utils/math-utils')
+const {
+  calculatePercentage,
+} = require('./utils/mathutils')
 const sleep = require('sleep')
 
 sleep.sleep(5)
@@ -32,7 +31,11 @@ connect()
 
 var args = process.argv.slice(2)
 
-const courseConfig = selectConfig(args[args.length - 1])
+const courseConfig = selectConfig(args[0])
+const startTime = args[1]
+const endTime = args[2]
+
+const DEFAULT_NEWER_THAN = 2592000000 * 6 // 6 months 
 
 /*
   - course completion status
@@ -40,7 +43,7 @@ const courseConfig = selectConfig(args[args.length - 1])
   -
 */
 function getProgressWithValidation(data) {
-  const { answererId, answers, quizzes } = data
+  const { answererId, answers, quizzes } = data
 
   const quizIds = quizzes.map(quiz => quiz._id)
 
@@ -49,64 +52,74 @@ function getProgressWithValidation(data) {
 
   const answerQuizIds = Array.from(answers.keys()) // map(answer => answer.quizId.toString());
 
-  const isAnswered = (entry) => ~answerQuizIds.indexOf(entry.quiz._id.toString())
-  const isDeprecated = (entry) => _.get(entry, 'answer[0].deprecated', false)
-  const isRejected = (entry) => _.get(entry, 'answer[0].rejected', false)
+  const isAnswered = entry => ~answerQuizIds.indexOf(entry.quiz._id.toString())
+  const isDeprecated = entry => _.get(entry, 'answer[0].deprecated', false)
+  const isRejected = entry => _.get(entry, 'answer[0].rejected', false)
 
-  const progress = _.groupBy(quizzes.map(quiz => {
-    let answersForQuiz = answers.get(quiz._id.toString()) || []
-    let answer = answersForQuiz //answers[quiz._id] || []
+  const progress = _.groupBy(
+    quizzes.map(quiz => {
+      let answersForQuiz = answers.get(quiz._id.toString()) || []
+      let answer = answersForQuiz //answers[quiz._id] || []
 
-    if (answersForQuiz.length > 0) {
-      let newestDate = 0
+      if (answersForQuiz.length > 0) {
+        let newestDate = 0
 
-      newestDate = answer[0].createdAt
+        newestDate = answer[0].createdAt
 
-      // answers now come sorted by date from backend
+        // answers now come sorted by date from backend
 
-      /*       answersForQuiz.forEach(answerForQuiz => {
+        /*       answersForQuiz.forEach(answerForQuiz => {
         if (answerForQuiz.updatedAt > newestDate) {
           answer = [answerForQuiz] // expecting [0]...
           newestDate = answerForQuiz.updatedAt
         }
       }) */
-      latestAnswerDate = Math.max(newestDate, latestAnswerDate)
-    }
+        latestAnswerDate = Math.max(newestDate, latestAnswerDate)
+      }
 
-    let returnObject = {
-      quiz,
-      answer: answers && answer.length > 0 ? answer : [],
-    }
+      let returnObject = {
+        quiz,
+        answer: answers && answer.length > 0 ? answer : [],
+      }
 
-    return returnObject
-  }), entry => {
-    if (isRejected(entry) && !isDeprecated(entry)) { return 'rejected' }
-    if (isAnswered(entry) && !isDeprecated(entry)) { return 'answered' }
+      return returnObject
+    }),
+    entry => {
+      if (isRejected(entry) && !isDeprecated(entry)) {
+        return 'rejected'
+      }
+      if (isAnswered(entry) && !isDeprecated(entry)) {
+        return 'answered'
+      }
 
-    return 'notAnswered'
-  })
+      return 'notAnswered'
+    },
+  )
 
-  if (isNaN(latestAnswerDate)) { // hmm
+  if (isNaN(latestAnswerDate)) {
+    // hmm
     latestAnswerDate = 0
   }
 
   let returnObject = {
     answererId,
     essaysAwaitingPeerReviewsGiven,
-    latestAnswerDate
+    latestAnswerDate,
   }
 
-  returnObject = Object.assign(
-    {},
-    returnObject,
-    validateProgress(progress))
+  returnObject = Object.assign({}, returnObject, validateProgress(progress))
 
   return returnObject
 }
 
 function updateCompletion(data) {
   return new Promise((resolve, reject) => {
-    const { answererId, scoreObject, completionAnswersDate, partialCompleted } = data
+    const {
+      answererId,
+      scoreObject,
+      completionAnswersDate,
+      partialCompleted,
+    } = data
 
     const completed =
       scoreObject.progress >= courseConfig.MINIMUM_PROGRESS_TO_PASS &&
@@ -116,75 +129,82 @@ function updateCompletion(data) {
       console.log('Answerer', answererId, 'has differing states for completion')
     }
 
-    CourseState.findOne( // andupdate
-      { answererId,
-        courseId: courseConfig.COURSE_ID
-      }
-    ).then(courseState => {
-      let completionDate
+    CourseState.findOne(
+      // andupdate
+      { answererId, courseId: courseConfig.COURSE_ID },
+    )
+      .then(courseState => {
+        let completionDate
 
-      if (!_.get(courseState, 'completion.completed') && completed) {
-        // either new coursestate or hadn't previously completed but has now
-        completionDate = Date.now()
-      } else {
-        completionDate = _.get(courseState, 'completion.completionDate', null)
-      }
+        if (!_.get(courseState, 'completion.completed') && completed) {
+          // either new coursestate or hadn't previously completed but has now
+          completionDate = Date.now()
+        } else {
+          completionDate = _.get(courseState, 'completion.completionDate', null)
+        }
 
-      let completionData = {
-        data: scoreObject,
-        completed,
-        completionDate,
-        completionAnswersDate,
-        confirmationSent: false
-      }
+        let completionData = {
+          data: scoreObject,
+          completed,
+          completionDate,
+          completionAnswersDate,
+          confirmationSent: false,
+        }
 
+        if (!courseState) {
+          const newCourseState = CourseState({
+            answererId,
+            courseId: courseConfig.COURSE_ID,
+            completion: completionData,
+          })
 
-      if (!courseState) {
-        const newCourseState = CourseState({
-          answererId,
-          courseId: courseConfig.COURSE_ID,
-          completion: completionData
-        })
+          return newCourseState.save()
+        }
 
-        return newCourseState.save()
-      }
+        if (!_.get(courseState, 'completion.completed')) {
+          // don't change data if confirmation already sent
+          courseState.completion = completionData
 
-      if (!_.get(courseState, 'completion.completed')) {
-        // don't change data if confirmation already sent
-        courseState.completion = completionData
+          return courseState.save()
+        }
+
+        // let's update the completion answer date at least
+        courseState.completion.completionAnswersDate = completionAnswersDate
 
         return courseState.save()
-      }
-
-      // let's update the completion answer date at least
-      courseState.completion.completionAnswersDate = completionAnswersDate
-
-      return courseState.save()
-    })
+      })
       .then(state => resolve(state))
       .catch(err => reject(err))
   })
 }
 
-const mapAnswers = (answers) => {
+const mapAnswers = answers => {
   const answersForAnswerer = new Map()
 
   answers.forEach(answer => {
     if (!answersForAnswerer.has(answer.answererId)) {
       answersForAnswerer.set(answer.answererId, new Map())
     }
-    if (!answersForAnswerer.get(answer.answererId).has(answer.quizId.toString())) {
-      answersForAnswerer.get(answer.answererId).set(answer.quizId.toString(), [])
+    if (
+      !answersForAnswerer.get(answer.answererId).has(answer.quizId.toString())
+    ) {
+      answersForAnswerer
+        .get(answer.answererId)
+        .set(answer.quizId.toString(), [])
     }
-    let value = answersForAnswerer.get(answer.answererId).get(answer.quizId.toString())
+    let value = answersForAnswerer
+      .get(answer.answererId)
+      .get(answer.quizId.toString())
     value.push(answer)
-    answersForAnswerer.get(answer.answererId).set(answer.quizId.toString(), value)
+    answersForAnswerer
+      .get(answer.answererId)
+      .set(answer.quizId.toString(), value)
   })
 
   return answersForAnswerer
 }
 
-const mapEntry = (entry) => ({
+const mapEntry = entry => ({
   quizId: entry.quiz._id,
   answerId: entry.answer[0]._id,
   points: entry.validation.points,
@@ -198,8 +218,27 @@ const mapEntry = (entry) => ({
   type: entry.quiz.type,
   createdAt: entry.answer[0].createdAt,
   updatedAt: entry.answer[0].updatedAt,
-  earliestCreatedAt: entry.answer[entry.answer.length - 1].createdAt
+  earliestCreatedAt: entry.answer[entry.answer.length - 1].createdAt,
 })
+
+const parseTime = (str) => {
+  if (!str || typeof str !== 'string') {
+    return 
+  }
+
+  const time = parseInt(str.slice(0, -1))
+  const factor = (str.slice(-1) || '').toLowerCase()
+  const factors = {
+    'y': 2592000000 * 12,
+    'm': 2592000000,
+  }
+
+  if (!Object.keys(factors).some(s => s === factor)) {
+    throw new Error(`invalid time! factor must be one of ${Object.keys(factors).join(', ')}`)
+  }
+
+  return time * factors[factor]
+}
 
 const getCompleted = async () => {
   const quizIds = await fetchQuizIds(courseConfig.COURSE_ID)
@@ -207,26 +246,44 @@ const getCompleted = async () => {
   console.log('initing...')
 
   const quizIdsMap = quizIds.map(quizId => mongoose.Types.ObjectId(quizId))
+  const currentDate = new Date()
+  const createdAt = {
+    $gte: startTime ? new Date(currentDate - parseTime(startTime)) : DEFAULT_NEWER_THAN,
+    $lte: endTime ? new Date(currentDate - parseTime(endTime)) : undefined
+  }
 
-  const answers = await QuizAnswer
-    .find({ quizId: { $in: quizIdsMap }, createdAt: { $gte: new Date(new Date() - 2592000000 * 6)}})
+  const answers = await QuizAnswer.find({
+    quizId: { $in: quizIdsMap },
+    createdAt
+/*     createdAt: { $gte: new Date(new Date() - 2592000000 * 6) }, */
+  })
     .sort({ createdAt: -1 })
     .exec()
 
-  const quizzes = await Quiz.findAnswerable({ _id: { $in: quizIdsMap }}).exec()
-  const countableQuizIds = quizzes.filter(quiz => !_.includes(quiz.tags, 'ignore')).map(quiz => quiz._id.toString())
+  const quizzes = await Quiz.findAnswerable({ _id: { $in: quizIdsMap } }).exec()
+  const countableQuizIds = quizzes
+    .filter(quiz => !_.includes(quiz.tags, 'ignore'))
+    .map(quiz => quiz._id.toString())
 
   const maxCountableNormalizedPoints = countableQuizIds.length
 
   const answererIds = _.uniq(answers.map(answer => answer.answererId))
   //const quizIds = _.uniq(answers.map(answer => answer._doc.quizId.toString()))
 
-  console.log(answererIds.length + ' unique answerers, '+ answers.length + ' answers to trawl through for ' + courseConfig.COURSE_ID)
+  console.log(
+    answererIds.length +
+      ' unique answerers, ' +
+      answers.length +
+      ' answers to trawl through for ' +
+      courseConfig.COURSE_ID,
+  )
 
-  const answersForSelectedAnswerers = await QuizAnswer
-  .find({ quizId: { $in: quizIdsMap }, answererId: { $in: answererIds }})
-  .sort({ createdAt: -1 })
-  .exec()
+  const answersForSelectedAnswerers = await QuizAnswer.find({
+    quizId: { $in: quizIdsMap },
+    answererId: { $in: answererIds },
+  })
+    .sort({ createdAt: -1 })
+    .exec()
 
   let answersForAnswerer = mapAnswers(answersForSelectedAnswerers)
 
@@ -234,118 +291,151 @@ const getCompleted = async () => {
 
   let count = 0
 
-  const completed = await Promise.all(answererIds.map(async (answererId) => {
-    //console.log(answererId)
-    const currentAnswers = answersForAnswerer.get(answererId)
+  const completed = await Promise.all(
+    answererIds.map(async answererId => {
+      //console.log(answererId)
+      const currentAnswers = answersForAnswerer.get(answererId)
 
-    const progress = getProgressWithValidation({
-      answererId,
-      answers: currentAnswers,
-      quizzes
-    })
+      const progress = getProgressWithValidation({
+        answererId,
+        answers: currentAnswers,
+        quizzes,
+      })
 
-    count += 1
-    const percentage = precise_round(count / answererIds.length * 100, 0)
-    /*           if (!_.includes(percentagesShown, percentage)) {
+      count += 1
+      /*           if (!_.includes(percentagesShown, percentage)) {
           percentagesShown.push(percentage)
           printProgress(percentage)
         } */
 
-    const score = calculatePercentage(progress.validation.normalizedPoints, progress.validation.maxNormalizedPoints)
-    const pointsPercentage = calculatePercentage(progress.validation.points, progress.validation.maxPoints)
+      const score = calculatePercentage(
+        progress.validation.normalizedPoints,
+        progress.validation.maxNormalizedPoints,
+      )
+      const pointsPercentage = calculatePercentage(
+        progress.validation.points,
+        progress.validation.maxPoints,
+      )
 
-    // go through answers in submission order and determine the date when the answerer
-    // could have been potentially have completed
+      // go through answers in submission order and determine the date when the answerer
+      // could have been potentially have completed
 
-    const answerValidation = progress.answered.map(entry => mapEntry(entry))
+      const answerValidation = progress.answered.map(entry => mapEntry(entry))
 
-    const sortedAnswers = _.sortBy(answerValidation, 'earliestCreatedAt') //createdAt
+      const sortedAnswers = _.sortBy(answerValidation, 'earliestCreatedAt') //createdAt
 
-    let partialNormalizedPoints = 0
-    let partialConfirmedAmount = 0
-    let partialCompleted = false
-    let completionAnswersDate = null
+      let partialNormalizedPoints = 0
+      let partialConfirmedAmount = 0
+      let partialCompleted = false
+      let completionAnswersDate = null
 
-    let prevDate = 0
+      let prevDate = 0
 
-    if (score >= courseConfig.MINIMUM_SCORE_TO_PASS) {
-      sortedAnswers.some((entry => {
-        if (prevDate > entry.earliestCreatedAt) { // createdAt
-          return Promise.reject(new Error('answer sorting is borked?'))
-        }
-
-        prevDate = entry.earliestCreatedAt // createdAt
-
-        if (_.includes(countableQuizIds, entry.quizId.toString())) {
-          partialNormalizedPoints += entry.normalizedPoints
-          partialConfirmedAmount += entry.confirmed ? 1 : 0
-        }
-
-        let partialProgress = calculatePercentage(partialConfirmedAmount, maxCountableNormalizedPoints)
-        let partialScore = calculatePercentage(partialNormalizedPoints, maxCountableNormalizedPoints)
-
-        if (partialProgress > 100 || partialScore > 100) {
-          return Promise.reject(new Error('your progress/score calculations are wrong', progress, partialProgress, partialScore))
-        }
-
-        if (partialProgress >= courseConfig.MINIMUM_PROGRESS_TO_PASS) {
-          //                partialScore >= config.MINIMUM_SCORE_TO_PASS) {
-          completionAnswersDate = entry.earliestCreatedAt // createdAt
-          partialCompleted = true
-
-          if (partialProgress > progress.validation.progress || partialScore > score) {
-            console.log('%s official p/s %d/%d partial p/s %d/%d', answererId, progress.validation.progress, score, partialProgress, partialScore)
+      if (score >= courseConfig.MINIMUM_SCORE_TO_PASS) {
+        sortedAnswers.some(entry => {
+          if (prevDate > entry.earliestCreatedAt) {
+            // createdAt
+            return Promise.reject(new Error('answer sorting is borked?'))
           }
 
-          return true
-        }
+          prevDate = entry.earliestCreatedAt // createdAt
 
-        return false
-      }))
-    }
+          if (_.includes(countableQuizIds, entry.quizId.toString())) {
+            partialNormalizedPoints += entry.normalizedPoints
+            partialConfirmedAmount += entry.confirmed ? 1 : 0
+          }
 
-    const scoreObject = {
-      answererId,
-      answerValidation,
-      points: progress.validation.points,
-      maxPoints: progress.validation.maxPoints,
-      normalizedPoints: progress.validation.normalizedPoints,
-      maxNormalizedPoints: progress.validation.maxNormalizedPoints,
-      maxCompletedPoints: progress.validation.maxCompletedPoints,
-      maxCompletedNormalizedPoints: progress.validation.maxCompletedNormalizedPoints,
-      progress: progress.validation.progress,
-      score,
-      pointsPercentage,
-      date: Date.now(),
-      latestAnswerDate: progress.latestAnswerDate
-    }
+          let partialProgress = calculatePercentage(
+            partialConfirmedAmount,
+            maxCountableNormalizedPoints,
+          )
+          let partialScore = calculatePercentage(
+            partialNormalizedPoints,
+            maxCountableNormalizedPoints,
+          )
 
+          if (partialProgress > 100 || partialScore > 100) {
+            return Promise.reject(
+              new Error(
+                'your progress/score calculations are wrong',
+                progress,
+                partialProgress,
+                partialScore,
+              ),
+            )
+          }
 
-    //console.log('completion:', answererId)
+          if (partialProgress >= courseConfig.MINIMUM_PROGRESS_TO_PASS) {
+            //                partialScore >= config.MINIMUM_SCORE_TO_PASS) {
+            completionAnswersDate = entry.earliestCreatedAt // createdAt
+            partialCompleted = true
 
-    try {
-      await updateCompletion({
+            if (
+              partialProgress > progress.validation.progress ||
+              partialScore > score
+            ) {
+              console.log(
+                '%s official p/s %d/%d partial p/s %d/%d',
+                answererId,
+                progress.validation.progress,
+                score,
+                partialProgress,
+                partialScore,
+              )
+            }
+
+            return true
+          }
+
+          return false
+        })
+      }
+
+      const scoreObject = {
         answererId,
-        scoreObject,
-        completionAnswersDate,
-        partialCompleted
-      })
-    } catch (err) {
-      throw err
-    }
+        answerValidation,
+        points: progress.validation.points,
+        maxPoints: progress.validation.maxPoints,
+        normalizedPoints: progress.validation.normalizedPoints,
+        maxNormalizedPoints: progress.validation.maxNormalizedPoints,
+        maxCompletedPoints: progress.validation.maxCompletedPoints,
+        maxCompletedNormalizedPoints:
+          progress.validation.maxCompletedNormalizedPoints,
+        progress: progress.validation.progress,
+        score,
+        pointsPercentage,
+        date: Date.now(),
+        latestAnswerDate: progress.latestAnswerDate,
+      }
 
-    if (progress.validation.progress >= courseConfig.MINIMUM_PROGRESS_TO_PASS &&
-          score >= courseConfig.MINIMUM_SCORE_TO_PASS) {
-      return scoreObject
-    }
+      //console.log('completion:', answererId)
 
-    return
-  }))
-    .then(results => (results || []).filter(v => !!v))
+      try {
+        await updateCompletion({
+          answererId,
+          scoreObject,
+          completionAnswersDate,
+          partialCompleted,
+        })
+      } catch (err) {
+        throw err
+      }
+
+      if (
+        progress.validation.progress >= courseConfig.MINIMUM_PROGRESS_TO_PASS &&
+        score >= courseConfig.MINIMUM_SCORE_TO_PASS
+      ) {
+        return scoreObject
+      }
+
+      return
+    }),
+  )
+    .then(results => (results || []).filter(v => !!v))
     .catch(err => Promise.reject(err))
 
   return completed
-/*     })
+  /*     })
     .then(completed => Promise.resolve(completed))
     .catch(err => Promise.reject(err)) */
 }
@@ -353,7 +443,7 @@ const getCompleted = async () => {
 setTimeout(() => {
   getCompleted()
     .then(response => {
-    /*   console.log('\n', JSON.stringify(response)) */
+      /*   console.log('\n', JSON.stringify(response)) */
       console.log(response.length + ' completed')
       // process.exit(0)
     })
@@ -362,6 +452,5 @@ setTimeout(() => {
       process.exit(1)
     })
 }, 2000)
-
 
 setInterval(() => {}, 1000)

--- a/bin/confirm/confirm-completion.js
+++ b/bin/confirm/confirm-completion.js
@@ -227,6 +227,7 @@ const parseTime = str => {
   const factors = {
     y: 2592000000 * 12,
     m: 2592000000,
+    w: 604800000
   }
 
   if (!Object.keys(factors).some(s => s === factor)) {

--- a/pm2.json
+++ b/pm2.json
@@ -17,6 +17,39 @@
   },
   {
     "script"          : "bin/confirm/confirm-completion.js",
+    "name"            : "completion-en-newer-than-1m",
+    "exec_mode"       : "cluster",
+    "instances"       : "1",
+    "autorestart"     : true,
+    "cron_restart"    : "5 * * * *",
+    "log_date_format" : "YYYY-MM-DD HH:mm Z",
+    "args"            : "elements-of-ai 1m",
+    "node_args"       : "--max-old-space-size=8192"
+  },
+  {
+    "script"          : "bin/confirm/confirm-completion.js",
+    "name"            : "completion-en-1m-to-6m",
+    "exec_mode"       : "cluster",
+    "instances"       : "1",
+    "autorestart"     : true,
+    "cron_restart"    : "25 * * * *",
+    "log_date_format" : "YYYY-MM-DD HH:mm Z",
+    "args"            : "elements-of-ai 6m 1m",
+    "node_args"       : "--max-old-space-size=10192"
+  },
+  {
+    "script"          : "bin/confirm/confirm-completion.js",
+    "name"            : "completion-en-older-than-6m",
+    "exec_mode"       : "cluster",
+    "instances"       : "1",
+    "autorestart"     : true,
+    "cron_restart"    : "50 * * * *",
+    "log_date_format" : "YYYY-MM-DD HH:mm Z",
+    "args"            : "elements-of-ai 10y 6m",
+    "node_args"       : "--max-old-space-size=10192"
+  },
+  {
+    "script"          : "bin/confirm/confirm-completion.js",
     "name"            : "completion",
     "exec_mode"       : "cluster",
     "instances"       : "1",

--- a/pm2.json
+++ b/pm2.json
@@ -49,16 +49,6 @@
     "node_args"       : "--max-old-space-size=10192"
   },
   {
-    "script"          : "bin/confirm/confirm-completion.js",
-    "name"            : "completion",
-    "exec_mode"       : "cluster",
-    "instances"       : "1",
-    "autorestart"     : true,
-    "cron_restart"    : "55 * * * *",
-    "log_date_format" : "YYYY-MM-DD HH:mm Z",
-    "node_args"       : "--max-old-space-size=10192"
-  },
-  {
     "script"          : "bin/confirm/confirm-essays.js",
     "name"            : "essays-fi",
     "exec_mode"       : "cluster",


### PR DESCRIPTION
Completion script now takes optional parameters to filter for answers newer than and older than given date.
First parameter is always the course.

Examples:
`confirm-completion elements-of-ai 1m` - go through answers that are no older than 1 month
`confirm-completion elements-of-ai 1y 1m` - go through answers that are no older than 1 year and no newer than 1 month
`confirm-completion elements-of-ai` - default to 6 months

Also `w` for weeks.

Also added some new jobs to pm2.json, feel free to edit - now they're newer than 1m run every 5 minutes, 1-6 months every 25, 6 months-10 years every 50. 